### PR TITLE
Check the existence of the make method before calling it. fixed #4

### DIFF
--- a/src/entity-factory.ts
+++ b/src/entity-factory.ts
@@ -90,7 +90,9 @@ export class EntityFactory<Entity, Settings> {
         if (typeof entity[attribute] === 'object' && !(entity[attribute] instanceof Date)) {
           const subEntityFactory = entity[attribute];
           try {
-            entity[attribute] = await (subEntityFactory as any).make();
+            if (typeof (subEntityFactory as any).make === 'function') {
+              entity[attribute] = await (subEntityFactory as any).make();
+            }
           } catch (e) {
             throw new Error(`Could not make ${(subEntityFactory as any).name}`);
           }


### PR DESCRIPTION
Sometimes we pass JSON or an array, which is an object type.
To avoid calling the "make" method, I added a small condition.