### PR TITLE
Add parameter to override the factory-generated properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,17 @@ await factory(User)()
 ...
 ```
 
+To override specific properties in all the generated entities, you can send an additional object
+containing the properties that you want to override as the first argument in the `.make()`
+and `.seed()` methods, or as second argument in the `.makeMany()` and `.seedMany()` methods.
+
+```typescript
+...
+await factory(User)()
+    .createMany(10, { roles: ['admin'], firstName: 'John' });
+...
+```
+
 To deal with relations you can use the entity manager like this.
 
 ```typescript

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,11 @@ import { EntityFactory } from './entity-factory';
 export type FactoryFunction<Entity, Settings> = (faker: typeof Faker, settings?: Settings) => Entity;
 
 /**
+ * EntityProperty defines an object whose keys and values must be properties of the given Entity.
+ */
+export type EntityProperty<Entity> = { [Property in keyof Entity]?: Entity[Property] };
+
+/**
  * Factory gets the EntityFactory to the given Entity and pass the settings along
  */
 export type Factory = <Entity, Settings>(entity: ObjectType<Entity>) => (settings?: Settings) => EntityFactory<Entity, Settings>;


### PR DESCRIPTION
This PR implements #7 that allows the user to override the properties for one or all the created entities by passing an object that contains the properties and their value. It resembles the way Laravel manages it. Very useful for large overrides.