### PR TITLE
feat(cli): add bin to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "TypeORM seeding",
   "main": "dist/typeorm-seeding.js",
   "module": "dist/typeorm-seeding.es.js",
+  "bin": {
+    "typeorm-seeding": "dist/cli.js"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Adding [`bin` field](https://docs.npmjs.com/files/package.json#bin) we can use `typeorm-seeding` in npm-scripts instead of writing `node_modules/typeorm-seeding/dist/cli..js`.