### PR TITLE
Fix CLI when running directly

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env nod
+#!/usr/bin/env node
 import 'reflect-metadata'
 import * as yargs from 'yargs'
 import { SeedCommand } from './commands/seed.command'


### PR DESCRIPTION
CLI did not run when calling directly, e.g.:

```bash
typeorm-seeding seed
```