### PR TITLE
Add next as valid option on pull request

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,7 @@ name: Pull request checks
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ master, next ]
 
 jobs:
   build:


### PR DESCRIPTION
Currently pull request only detects if destiny is `master`. Add `next` as a valid option.