### PR TITLE
Simplify how promises are being detected

### DIFF
--- a/src/utils/factory.test.ts
+++ b/src/utils/factory.test.ts
@@ -17,23 +17,30 @@ describe('getNameOfClass', () => {
     }
   })
 })
+
 describe('isPromiseLike', () => {
-  test('Passing a promise should return true', () => {
+  test('Passing promise should return true', () => {
     const promise = new Promise(() => void 0)
     expect(isPromiseLike(promise)).toBeTruthy()
   })
-  test('Passing no promise should return false', () => {
-    expect(isPromiseLike(undefined)).toBeFalsy()
-    expect(isPromiseLike(null)).toBeFalsy()
-    expect(isPromiseLike('')).toBeFalsy()
-    expect(isPromiseLike(42)).toBeFalsy()
-    expect(isPromiseLike(true)).toBeFalsy()
-    expect(isPromiseLike(false)).toBeFalsy()
-    expect(isPromiseLike([])).toBeFalsy()
-    expect(isPromiseLike({})).toBeFalsy()
-    expect(isPromiseLike((): any => void 0)).toBeFalsy()
-    class UserEntity {}
-    expect(isPromiseLike(new UserEntity())).toBeFalsy()
-    expect(isPromiseLike(new Date())).toBeFalsy()
+
+  test.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['string', ''],
+    ['number', 1],
+    ['boolean', true],
+    ['boolean', false],
+    ['array', []],
+    ['object', {}],
+    ['function', () => true],
+    ['date', new Date()],
+  ])('Passing %s should return false', (_, value) => {
+    expect(isPromiseLike(value)).toBeFalsy()
+  })
+
+  test('Passing class instace should return false', () => {
+    class Test {}
+    expect(isPromiseLike(new Test())).toBeFalsy()
   })
 })

--- a/src/utils/factory.util.ts
+++ b/src/utils/factory.util.ts
@@ -9,5 +9,5 @@ export const getNameOfEntity = <T>(entity: ObjectType<T>): string => {
   throw new Error('Enity is not defined')
 }
 
-export const isPromiseLike = (o: any): boolean =>
-  !!o && (typeof o === 'object' || typeof o === 'function') && typeof o.then === 'function' && !(o instanceof Date)
+export const isPromiseLike = (o: any): o is Promise<any> =>
+  o && Object.prototype.toString.call(o) === '[object Promise]'


### PR DESCRIPTION
Add a more readable way to detect if an object is a promise