### PR TITLE
Refactor: Connection helper methods

### DIFF
--- a/src/commands/config.command.ts
+++ b/src/commands/config.command.ts
@@ -1,7 +1,7 @@
 import * as yargs from 'yargs'
 import chalk from 'chalk'
 import { printError } from '../utils/log.util'
-import { configureConnection, createConnection, getConnectionOptions, setConnectionOptions } from '../connection'
+import { configureConnection, getConnectionOptions, setConnectionOptions } from '../connection'
 import { getConnectionOptions as TypeORMgetConnectionOptions } from 'typeorm'
 
 export class ConfigCommand implements yargs.CommandModule {

--- a/src/commands/config.command.ts
+++ b/src/commands/config.command.ts
@@ -1,7 +1,8 @@
 import * as yargs from 'yargs'
 import chalk from 'chalk'
 import { printError } from '../utils/log.util'
-import { configureConnection, getConnectionOptions } from '../connection'
+import { configureConnection, createConnection, getConnectionOptions, setConnectionOptions } from '../connection'
+import { getConnectionOptions as TypeORMgetConnectionOptions } from 'typeorm'
 
 export class ConfigCommand implements yargs.CommandModule {
   command = 'config'
@@ -36,8 +37,8 @@ export class ConfigCommand implements yargs.CommandModule {
         configName: args.configName as string,
         connection: args.connection as string,
       })
-      const option = await getConnectionOptions()
-      log(option)
+      const options = await getConnectionOptions()
+      log(options)
     } catch (error) {
       printError('Could not find the orm config file', error)
       process.exit(1)

--- a/src/commands/seed.command.ts
+++ b/src/commands/seed.command.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk'
 import { importSeed } from '../importer'
 import { loadFilePaths, importFiles } from '../utils/file.util'
 import { runSeeder } from '../typeorm-seeding'
-import { configureConnection, getConnectionOptions, ConnectionOptions, createConnection } from '../connection'
+import { configureConnection, getConnectionOptions, ConnectionOptions, fetchConnection } from '../connection'
 import { ClassConstructor } from '../types'
 
 export class SeedCommand implements yargs.CommandModule {
@@ -86,7 +86,7 @@ export class SeedCommand implements yargs.CommandModule {
     // Get database connection and pass it to the seeder
     spinner.start('Connecting to the database')
     try {
-      await createConnection()
+      await fetchConnection()
       spinner.succeed('Database connected')
     } catch (error) {
       panic(spinner, error as Error, 'Database connection failed! Check your TypeORM config.')

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -11,6 +11,7 @@ export declare type ConnectionOptions = TypeORMConnectionOptions & {
   seeds: string[]
 }
 let connectionOptions: ConnectionOptions
+let partialConnectionOptions: Partial<ConnectionOptions> = {}
 
 export type ConnectionConfiguration = {
   root?: string
@@ -57,8 +58,24 @@ export const getConnectionOptions = async (): Promise<ConnectionOptions> => {
 }
 
 export const setConnectionOptions = (options: Partial<ConnectionOptions>): void => {
-  connectionOptions = {
-    ...connectionOptions,
-    ...options,
-  } as ConnectionOptions
+  partialConnectionOptions = options
+}
+
+export const fetchConnection = async (): Promise<Connection> => {
+  const { connection: connectionName } = connectionConfiguration
+  if (connectionOptions === undefined) {
+    await readConnectionOptions()
+  }
+
+  let connection: Connection
+  try {
+    connection = getConnection(connectionName)
+  } catch {
+    connection = await TypeORMCreateConnection({
+      ...connectionOptions,
+      ...partialConnectionOptions,
+    } as TypeORMConnectionOptions)
+  }
+
+  return connection
 }

--- a/src/entity-factory.ts
+++ b/src/entity-factory.ts
@@ -1,9 +1,9 @@
 import * as Faker from 'faker'
-import { ObjectType, SaveOptions, Entity } from 'typeorm'
+import { ObjectType, SaveOptions, Entity, createConnection } from 'typeorm'
 import { FactoryFunction } from './types'
 import { isPromiseLike } from './utils/factory.util'
 import { printError, printWarning } from './utils/log.util'
-import { getConnectionOptions, createConnection } from './connection'
+import { getConnectionOptions } from './connection'
 
 export class EntityFactory<Entity, Context> {
   private mapFunction?: (entity: Entity) => Promise<Entity>

--- a/src/entity-factory.ts
+++ b/src/entity-factory.ts
@@ -1,9 +1,9 @@
 import * as Faker from 'faker'
-import { ObjectType, SaveOptions, Entity, createConnection } from 'typeorm'
+import { ObjectType, SaveOptions } from 'typeorm'
 import { FactoryFunction } from './types'
 import { isPromiseLike } from './utils/factory.util'
 import { printError, printWarning } from './utils/log.util'
-import { getConnectionOptions } from './connection'
+import { fetchConnection, getConnectionOptions } from './connection'
 
 export class EntityFactory<Entity, Context> {
   private mapFunction?: (entity: Entity) => Promise<Entity>
@@ -39,8 +39,7 @@ export class EntityFactory<Entity, Context> {
    * Create makes a new entity and does persist it
    */
   public async create(overrideParams: Partial<Entity> = {}, saveOptions?: SaveOptions): Promise<Entity> {
-    const option = await getConnectionOptions()
-    const connection = await createConnection(option)
+    const connection = await fetchConnection()
     if (connection && connection.isConnected) {
       const em = connection.createEntityManager()
       try {

--- a/src/typeorm-seeding.ts
+++ b/src/typeorm-seeding.ts
@@ -1,11 +1,11 @@
 import 'reflect-metadata'
-import { ObjectType, getConnection, Connection, createConnection } from 'typeorm'
+import { ObjectType, Connection } from 'typeorm'
 
 import { EntityFactory } from './entity-factory'
 import { ClassConstructor, EntityFactoryDefinition, Factory, FactoryFunction } from './types'
 import { getNameOfEntity } from './utils/factory.util'
 import { loadFilePaths, importFiles } from './utils/file.util'
-import { configureConnection, getConnectionOptions, ConnectionConfiguration } from './connection'
+import { configureConnection, getConnectionOptions, ConnectionConfiguration, fetchConnection } from './connection'
 import { Seeder } from './seeder'
 
 // -------------------------------------------------------------------------
@@ -46,7 +46,7 @@ export const factory: Factory =
 export const runSeeder = async (clazz: ClassConstructor<any>): Promise<void> => {
   const seeder = new clazz()
   if (seeder instanceof Seeder) {
-    const connection = await createConnection()
+    const connection = await fetchConnection()
     seeder.run(factory, connection)
   }
 }
@@ -57,8 +57,7 @@ export const runSeeder = async (clazz: ClassConstructor<any>): Promise<void> => 
 
 export const useRefreshDatabase = async (options: ConnectionConfiguration = {}): Promise<Connection> => {
   configureConnection(options)
-  const option = await getConnectionOptions()
-  const connection = await createConnection(option)
+  const connection = await fetchConnection()
   if (connection && connection.isConnected) {
     await connection.dropDatabase()
     await connection.synchronize()
@@ -67,7 +66,7 @@ export const useRefreshDatabase = async (options: ConnectionConfiguration = {}):
 }
 
 export const tearDownDatabase = async (): Promise<void> => {
-  const connection = await createConnection()
+  const connection = await fetchConnection()
   return connection && connection.isConnected ? connection.close() : undefined
 }
 

--- a/src/typeorm-seeding.ts
+++ b/src/typeorm-seeding.ts
@@ -1,11 +1,11 @@
 import 'reflect-metadata'
-import { ObjectType, getConnection, Connection } from 'typeorm'
+import { ObjectType, getConnection, Connection, createConnection } from 'typeorm'
 
 import { EntityFactory } from './entity-factory'
 import { ClassConstructor, EntityFactoryDefinition, Factory, FactoryFunction } from './types'
 import { getNameOfEntity } from './utils/factory.util'
 import { loadFilePaths, importFiles } from './utils/file.util'
-import { ConfigureOption, configureConnection, getConnectionOptions, createConnection } from './connection'
+import { configureConnection, getConnectionOptions, ConnectionConfiguration } from './connection'
 import { Seeder } from './seeder'
 
 // -------------------------------------------------------------------------
@@ -55,7 +55,7 @@ export const runSeeder = async (clazz: ClassConstructor<any>): Promise<void> => 
 // Facade functions for testing
 // -------------------------------------------------------------------------
 
-export const useRefreshDatabase = async (options: ConfigureOption = {}): Promise<Connection> => {
+export const useRefreshDatabase = async (options: ConnectionConfiguration = {}): Promise<Connection> => {
   configureConnection(options)
   const option = await getConnectionOptions()
   const connection = await createConnection(option)
@@ -71,7 +71,7 @@ export const tearDownDatabase = async (): Promise<void> => {
   return connection && connection.isConnected ? connection.close() : undefined
 }
 
-export const useSeeding = async (options: ConfigureOption = {}): Promise<void> => {
+export const useSeeding = async (options: ConnectionConfiguration = {}): Promise<void> => {
   configureConnection(options)
   const option = await getConnectionOptions()
   const factoryFiles = loadFilePaths(option.factories)


### PR DESCRIPTION
Some of the functions inside connection file were so big, and also some of them were duplicating code from `typeorm`