### PR TITLE
Rethrow error when entity save fails

### DIFF
--- a/src/entity-factory.ts
+++ b/src/entity-factory.ts
@@ -49,7 +49,7 @@ export class EntityFactory<Entity, Context> {
       } catch (error) {
         const message = 'Could not save entity'
         printError(message, error)
-        throw new Error(message)
+        throw error;
       }
     } else {
       const message = 'No db connection is given'


### PR DESCRIPTION
This will provide the full context on why the save failed, even if tests are running with `--silent`.