### PR TITLE
deps: migrate `faker` to `@faker-js/faker`

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,11 +246,11 @@ define: <Entity, Context>(entity: Entity, factoryFn: FactoryFunction<Entity, Con
 ```
 
 ```typescript
-import Faker from 'faker'
+import type { Faker } from '@faker-js/faker'
 import { define } from 'typeorm-seeding'
 import { User } from '../entities'
 
-define(User, (faker: typeof Faker, context: { roles: string[] }) => { ... })
+define(User, (faker: Faker, context: { roles: string[] }) => { ... })
 ```
 
 ### `factory`

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
+    "@faker-js/faker": "^7.3.0",
     "chalk": "^4.0.0",
     "faker": "5.5.3",
     "glob": "7.1.6",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   "dependencies": {
     "@faker-js/faker": "^7.3.0",
     "chalk": "^4.0.0",
-    "faker": "5.5.3",
     "glob": "7.1.6",
     "ora": "4.0.3",
     "reflect-metadata": "0.1.13",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@semantic-release/git": "^9.0.0",
     "@types/bcryptjs": "^2.4.2",
     "@types/chalk": "^2.2.0",
-    "@types/faker": "^5.5.8",
     "@types/glob": "7.1.1",
     "@types/jest": "^25.2.1",
     "@types/node": "13.11.1",

--- a/sample/factories/pet.factory.ts
+++ b/sample/factories/pet.factory.ts
@@ -1,10 +1,10 @@
-import Faker from 'faker'
+import type { Faker, GenderType } from '@faker-js/faker'
 import { define, factory } from '../../src/typeorm-seeding'
 import { Pet } from '../entities/Pet.entity'
 import { User } from '../entities/User.entity'
 
-define(Pet, (faker: typeof Faker) => {
-  const gender = faker.datatype.number(1)
+define(Pet, (faker: Faker) => {
+  const gender: GenderType = faker.datatype.boolean() ? 'female' : 'male';
   const name = faker.name.firstName(gender)
 
   const pet = new Pet()

--- a/sample/factories/user.factory.ts
+++ b/sample/factories/user.factory.ts
@@ -1,9 +1,9 @@
-import * as Faker from 'faker'
+import type { Faker, GenderType } from '@faker-js/faker'
 import { define } from '../../src/typeorm-seeding'
 import { User } from '../entities/User.entity'
 
-define(User, (faker: typeof Faker) => {
-  const gender = faker.datatype.number(1)
+define(User, (faker: Faker) => {
+  const gender: GenderType = faker.datatype.boolean() ? 'female' : 'male';
   const firstName = faker.name.firstName(gender)
   const lastName = faker.name.lastName(gender)
   const email = faker.internet.email(firstName, lastName)

--- a/src/entity-factory.ts
+++ b/src/entity-factory.ts
@@ -1,4 +1,4 @@
-import * as Faker from 'faker'
+import { faker } from '@faker-js/faker'
 import { ObjectType, SaveOptions } from 'typeorm'
 import { FactoryFunction, EntityProperty } from './types'
 import { isPromiseLike } from './utils/factory.util'
@@ -97,7 +97,7 @@ export class EntityFactory<Entity, Context> {
       throw new Error('Could not found entity')
     }
 
-    let entity = await this.resolveEntity(this.factory(Faker, this.context), isSeeding)
+    let entity = await this.resolveEntity(this.factory(faker, this.context), isSeeding)
     if (this.mapFunction) {
       entity = await this.mapFunction(entity)
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import * as Faker from 'faker'
+import type { Faker } from '@faker-js/faker'
 import { Connection, ObjectType } from 'typeorm'
 
 import { EntityFactory } from './entity-factory'
@@ -6,7 +6,7 @@ import { EntityFactory } from './entity-factory'
 /**
  * FactoryFunction is the fucntion, which generate a new filled entity
  */
-export type FactoryFunction<Entity, Context> = (faker: typeof Faker, context?: Context) => Entity
+export type FactoryFunction<Entity, Context> = (faker: Faker, context?: Context) => Entity
 
 /**
  * EntityProperty defines an object whose keys and values must be properties of the given Entity.

--- a/yarn.lock
+++ b/yarn.lock
@@ -272,6 +272,11 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@faker-js/faker@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-7.3.0.tgz#a508df35ded585c4e071cb5d9d7c89623c837fae"
+  integrity sha512-1W0PZezq2rxlAssoWemi9gFRD8IQxvf0FPL5Km3TOmGHFG7ib0TbFBJ0yC7D/1NsxunjNTK6WjUXV8ao/mKZ5w==
+
 "@iarna/cli@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@iarna/cli/-/cli-1.2.0.tgz#0f7af5e851afe895104583c4ca07377a8094d641"

--- a/yarn.lock
+++ b/yarn.lock
@@ -736,11 +736,6 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
-"@types/faker@^5.5.8":
-  version "5.5.8"
-  resolved "https://registry.yarnpkg.com/@types/faker/-/faker-5.5.8.tgz#6649adfdfdbb0acf95361fc48f2d0ca6e88bd1cf"
-  integrity sha512-bsl0rYsaZVHlZkynL5O04q6YXDmVjcid6MbOHWqvtE2WWs/EKhp0qchDDhVWlWyQXUffX1G83X9LnMxRl8S/Mw==
-
 "@types/glob@7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2671,11 +2671,6 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-faker@5.5.3:
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/faker/-/faker-5.5.3.tgz#c57974ee484431b25205c2c8dc09fda861e51e0e"
-  integrity sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==
-
 fast-deep-equal@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"


### PR DESCRIPTION
Based on the suggestion from #216.

I tried my best to update all `faker` references with the new, official `@faker.js/faker` package. This change is highly suggested since `faker` is no longer maintained.

Sadly most of the dependencies in this repo are out of date which leads to compile time errors since `@faker.js/faker` requires at least typescript v4 for typing. So an update of the `typescript` package is required for this PR to be able to merge successfully (which requires `ts-jest` and `jest` version updates as a result).